### PR TITLE
Added the option to limit how many messages or reactions a collector can have (own option of discord.js)

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
         "build": "tsc",
         "test": "npm run build && node --enable-source-maps dist/test.js"
     },
-    "dependencies": {
-        "discord.js": "12.5.3"
+    "peerDependencies": {
+        "discord.js": ">=12.0.0"
     },
     "devDependencies": {
         "@types/node": "14.14.37",

--- a/src/test.ts
+++ b/src/test.ts
@@ -67,6 +67,28 @@ client.on('message', async msg => {
             prompt.react('🍎');
             prompt.react('🍌');
 
+            /* Users Voting Example
+                prompt.react('✅');
+                await CollectorUtils.collectByReaction(
+                    prompt,
+                    // Collect Filter
+                    (msgReaction: MessageReaction, reactor: User) => reactor.bot === false,
+                    // Stop Filter
+                    (nextMsg: Message) =>
+                        nextMsg.author.id === msg.author.id && nextMsg.content === 'stop',
+                    // Retrieve Result
+                    async (msgReaction: MessageReaction, reactor: User) => {
+                        console.log('ok');
+                    },
+                    // Expire Function
+                    async () => {
+                        await msg.channel.send('Voting finished!');
+                    },
+                    // Options
+                    { time: 10000, reset: true, max: 2 }
+                );
+            */
+
             let favoriteFruit: string = await CollectorUtils.collectByReaction(
                 prompt,
                 // Collect Filter


### PR DESCRIPTION
This option is useful in certain cases and I made it optional, it is not mandatory to put it. It is also an option of the discord.js Message Collector options.

I took on the task of resolving my own issue #2 